### PR TITLE
fix: replace non-existent top_op.kills with roundsPlayed in !stats

### DIFF
--- a/bot/cog_stats.py
+++ b/bot/cog_stats.py
@@ -245,7 +245,7 @@ class StatsCog(commands.Cog, name="Stats"):
             top_op = operator_stats[0]
             embed.add_field(
                 name="Meistgespielter Operator",
-                value=f"{top_op.name} ({top_op.kills} kills total)",
+                value=f"{top_op.name} ({top_op.roundsPlayed} Runden gespielt)",
                 inline=False,
             )
 


### PR DESCRIPTION
Der !stats Befehl hat still versagt weil OperatorStat kein kills-Feld hat.

Fix: top_op.kills → top_op.roundsPlayed

## Summary by Sourcery

Bug Fixes:
- Fix !stats command failure by using the existing roundsPlayed field instead of a non-existent kills field for operator stats.