### PR TITLE
fix: URL-encode operator name in iconUrl

### DIFF
--- a/r6api/client.py
+++ b/r6api/client.py
@@ -11,6 +11,7 @@ Endpoints used:
 """
 
 import logging
+import urllib.parse
 import httpx
 from pydantic import BaseModel
 
@@ -235,7 +236,7 @@ class R6DataClient:
                 name=name,
                 roundsPlayed=stats["played"],
                 roundsWon=stats["won"],
-                iconUrl=f"https://r6data.eu/assets/img/operators/{name.lower()}.png",
+                iconUrl=f"https://r6data.eu/assets/img/operators/{urllib.parse.quote(name.lower())}.png",
             )
             for name, stats in merged.items()
             if stats["played"] > 0


### PR DESCRIPTION
Operatoren wie Jäger enthalten Nicht-ASCII-Zeichen im Namen. Die generierte URL (z.B. `jäger.png`) ist für Discord kein valider URL → HTTPException 400.

Fix: `urllib.parse.quote()` auf den Operator-Namen anwenden.

## Summary by Sourcery

Bug Fixes:
- Fix invalid operator icon URLs for names containing non-ASCII characters by URL-encoding the operator name in the icon path.