### PR TITLE
feat: switch AI agents from Gemini to Claude Haiku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 DISCORD_TOKEN=your_discord_bot_token
 R6DATA_API_KEY=your_r6data_api_key
 DATABASE_URL=postgresql://r6bot:r6bot@localhost:5432/r6bot
-GOOGLE_API_KEY=your_gemini_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
 DAILY_HOUR=22
 DAILY_MINUTE=0
 SNAPSHOT_HOUR=0

--- a/agent/critic.py
+++ b/agent/critic.py
@@ -1,7 +1,7 @@
 """
 agent/critic.py — pydantic-ai agents for generating player critiques.
 
-Uses Claude (claude-sonnet-4-6) via pydantic-ai.
+Uses Claude (claude-haiku-4-5-20251001) via pydantic-ai.
 
 Agents:
 - critic_agent: Takes a DailyStats object and returns a CritiqueOutput.
@@ -17,8 +17,8 @@ Models:
 
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_ai.models.google import GoogleModel
-from pydantic_ai.providers.google import GoogleProvider
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
 from config import settings
 
 
@@ -60,7 +60,7 @@ class LazyDayOutput(BaseModel):
 
 # Toxic R6 coach agent — roasts a player's daily stats
 critic_agent: Agent[None, CritiqueOutput] = Agent(
-    model=GoogleModel("gemini-2.0-flash", provider=GoogleProvider(api_key=settings.google_api_key)),
+    model=AnthropicModel("claude-haiku-4-5-20251001", provider=AnthropicProvider(api_key=settings.anthropic_api_key)),
     output_type=CritiqueOutput,
     system_prompt=(
         "Du bist ein toxischer Rainbow Six Siege Coach. "
@@ -78,7 +78,7 @@ critic_agent: Agent[None, CritiqueOutput] = Agent(
 
 # Lazy-day agent — generates a varied @everyone taunt when nobody played
 lazy_day_agent: Agent[None, LazyDayOutput] = Agent(
-    model=GoogleModel("gemini-2.0-flash", provider=GoogleProvider(api_key=settings.google_api_key)),
+    model=AnthropicModel("claude-haiku-4-5-20251001", provider=AnthropicProvider(api_key=settings.anthropic_api_key)),
     output_type=LazyDayOutput,
     system_prompt=(
         "Du bist ein zynischer Discord-Bot für eine Rainbow Six Siege Gruppe. "

--- a/config.py
+++ b/config.py
@@ -33,8 +33,8 @@ class Settings(BaseSettings):
     # Database (asyncpg DSN, e.g. postgresql://user:pass@host:5432/db)
     database_url: str
 
-    # Google Gemini / pydantic-ai
-    google_api_key: str
+    # Anthropic Claude / pydantic-ai
+    anthropic_api_key: str
 
     # Scheduler: when to post the daily report (24-hour clock)
     daily_hour: int = 22

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ httpx>=0.27.0
 asyncpg>=0.29.0
 apscheduler>=3.10.0
 python-dotenv>=1.0.0
-google-generativeai>=0.8.0
+anthropic>=0.40.0


### PR DESCRIPTION
Gemini Free Tier hatte limit=0 und hat alle AI-Calls blockiert.

Umgestellt auf `claude-haiku-4-5-20251001` via AnthropicModel/AnthropicProvider.

**Wichtig:** `ANTHROPIC_API_KEY` muss in der `.env` gesetzt werden (statt `GOOGLE_API_KEY`).

## Summary by Sourcery

Switch AI agents from Google Gemini to Anthropic Claude Haiku for generating player critiques and lazy-day taunts.

Bug Fixes:
- Restore AI functionality by replacing the non-working Gemini Free Tier with a functioning Claude Haiku model.

Enhancements:
- Update critic and lazy-day agents to use AnthropicModel/AnthropicProvider with Claude Haiku.
- Rename configuration to use an Anthropic API key instead of a Google API key and update example environment variables accordingly.
- Replace the Google Gemini client dependency with the Anthropic Python client in requirements.