### PR TITLE
Fix/operator calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [Hotfix] — 10-04-2026 — v0.0.3-beta1.0
+
+### Fixed
+- **Operator-Stats API** — R6Data API hat die Response-Struktur geändert (verschachtelte `split > playlists > operators` → flaches `operators`-Array). Parsing in `r6api/client.py` angepasst, `platform_families`-Parameter entfernt.
+- **Daily Report** — Most-played Operator wird wieder korrekt im Embed angezeigt.
+
+### Changed
+- **Critic Agent** — Operator-Daten (`most_played_operator`, `operator_rounds`) aus dem AI-Kontext entfernt. Die KI bekommt keine Operator-Infos mehr, das Embed zeigt sie aber weiterhin an.
+
+---
+
 ## [Unreleased] — 03-04-2026 — v0.0.3
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # R6 Tracker Bot
 
+![Version](https://img.shields.io/badge/version-v0.0.3--beta1.0-blue)
+
 A Discord bot that tracks Rainbow Six Siege statistics for registered players and posts a daily AI-generated roast report every evening at 22:00.
 
 Built with **pydantic-ai + Claude (Anthropic)**, **discord.py**, **PostgreSQL**, and the [R6Data API](https://r6data.eu/api-docs).

--- a/agent/critic.py
+++ b/agent/critic.py
@@ -37,8 +37,6 @@ class DailyStats(BaseModel):
     kd_today: float          # Kill/death ratio for today's session
     wins: int                # Wins today
     losses: int              # Losses today
-    most_played_operator: str
-    operator_rounds: int     # Rounds played with the most-played operator today
 
 
 class CritiqueOutput(BaseModel):

--- a/bot/cog_admin.py
+++ b/bot/cog_admin.py
@@ -145,7 +145,7 @@ class AdminCog(commands.Cog, name="Admin"):
             description=(
                 f"```diff\n{status_block}\n```"
                 "```fix\n"
-                "Bot-Version: 0.0.2\n"
+                "Bot-Version: 0.0.3-beta1.0\n"
                 "Entwickelt von MaxNoelp\n"
                 "```"
             ),

--- a/bot/cog_daily.py
+++ b/bot/cog_daily.py
@@ -225,8 +225,6 @@ class DailyCog(commands.Cog, name="Daily"):
                 kd_today=_kd(kill_delta, death_delta),
                 wins=win_delta,
                 losses=loss_delta,
-                most_played_operator=most_played,
-                operator_rounds=op_rounds_day,
             )
 
             # Ask the pydantic-ai critic agent to roast this player
@@ -237,7 +235,7 @@ class DailyCog(commands.Cog, name="Daily"):
                 log.error("daily_report_job: critic agent error for %s: %s", username, exc)
                 continue
 
-            embed, ping = self._build_critique_embed(discord_id, username, daily_stats, critique)
+            embed, ping = self._build_critique_embed(discord_id, username, daily_stats, critique, most_played, op_rounds_day)
             posts.append((discord_id, username, embed, ping))
 
         # Gather all guild post-channel destinations
@@ -300,6 +298,8 @@ class DailyCog(commands.Cog, name="Daily"):
         username: str,
         stats: DailyStats,
         critique: CritiqueOutput,
+        most_played: str = "Unbekannt",
+        op_rounds: int = 0,
     ) -> tuple[discord.Embed, str]:
         """
         Build the Discord Embed for a player's daily critique.
@@ -343,7 +343,7 @@ class DailyCog(commands.Cog, name="Daily"):
         )
         embed.add_field(
             name="Operator",
-            value=f"{stats.most_played_operator} ({stats.operator_rounds} Runden)",
+            value=f"{most_played} ({op_rounds} Runden)",
             inline=True,
         )
         embed.add_field(

--- a/r6api/client.py
+++ b/r6api/client.py
@@ -203,43 +203,28 @@ class R6DataClient:
 
     async def get_operator_stats(self, username: str, platform: str = "uplay") -> list[OperatorStat]:
         platform = _normalise_platform(platform)
-        family = _PLATFORM_FAMILIES.get(platform, "pc")
         data = await self._get(
             "/api/stats",
             params={
                 "type": "operatorStats",
                 "nameOnPlatform": username,
                 "platformType": platform,
-                "platform_families": family,
             },
         )
 
         if not isinstance(data, dict):
             return []
 
-        # Merge lifetime rounds across all playlists per operator
-        playlists: dict = data.get("split", {}).get(family, {}).get("playlists", {})
-        merged: dict[str, dict] = {}
-        for playlist_data in playlists.values():
-            for op_data in playlist_data.get("operators", {}).values():
-                name = op_data.get("operator", "Unknown")
-                played = int(op_data["rounds"]["lifetime"].get("played", 0))
-                won    = int(op_data["rounds"]["lifetime"].get("won", 0))
-                if name not in merged:
-                    merged[name] = {"played": 0, "won": 0}
-                # Take max across playlists (avoids double-counting)
-                merged[name]["played"] = max(merged[name]["played"], played)
-                merged[name]["won"]    = max(merged[name]["won"], won)
-
+        operators_list = data.get("operators", [])
         result: list[OperatorStat] = [
             OperatorStat(
-                name=name,
-                roundsPlayed=stats["played"],
-                roundsWon=stats["won"],
-                iconUrl=f"https://r6data.eu/assets/img/operators/{urllib.parse.quote(name.lower())}.png",
+                name=op.get("operator", "Unknown"),
+                roundsPlayed=int(op.get("roundsPlayed", 0)),
+                roundsWon=int(op.get("wins", 0)),
+                iconUrl=f"https://r6data.eu/assets/img/operators/{urllib.parse.quote(op.get('operator', 'unknown').lower())}.png",
             )
-            for name, stats in merged.items()
-            if stats["played"] > 0
+            for op in operators_list
+            if int(op.get("roundsPlayed", 0)) > 0
         ]
         result.sort(key=lambda o: o.roundsPlayed, reverse=True)
         return result


### PR DESCRIPTION
# Fix error for Operator calls

- fix api call, new api enpoint
- remove most played op from daily report
- change version number

## Summary by Sourcery

Update operator stats handling to match the new R6Data API response and adjust downstream usage in the daily report and versioning.

Bug Fixes:
- Restore operator stats retrieval by adapting to the new flat `operators` array in the R6Data API response.
- Ensure the daily report embed again shows the correct most-played operator and rounds played.

Enhancements:
- Remove operator-specific fields from the AI critic context while still displaying operator info in the embed.
- Update displayed bot version and add a README badge and changelog entry for the new hotfix release.

Documentation:
- Document the hotfix release, operator-stats API changes, and daily report behavior in the changelog and README version badge.